### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 		<version.ibs.common.mybatis>0.0.3</version.ibs.common.mybatis>
 		<version.standard.taglibs>1.1.2</version.standard.taglibs>
 		<version.commons.logging>1.1.1</version.commons.logging>
-		<version.commons.collections>3.2.1</version.commons.collections>
+		<version.commons.collections>3.2.2</version.commons.collections>
 		<version.commons.lang>2.6</version.commons.lang>
 		<version.commons.io>1.3.2</version.commons.io>
 		<version.commons-beanutils-core>1.9.2</version.commons-beanutils-core>


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That is the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/
